### PR TITLE
Removed warnings when using rust 1.7.0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@
 // ---------------
 // 
 // You will need to have Rust installed, of course. It is available for download on
-// [the Rust website](https://www.rust-lang.org/). Make sure you get at least version 1.2.
+// [the Rust website](https://www.rust-lang.org/). Make sure you get at least version 1.3.
 // More detailed installation instructions are provided in
 // [the second chapter of The Book](https://doc.rust-lang.org/stable/book/installing-rust.html).
 // This will also install `cargo`, the tool responsible for building rust projects (or *crates*).

--- a/workspace/src/part03.rs
+++ b/workspace/src/part03.rs
@@ -57,7 +57,7 @@ pub fn main() {
 // Notice that I called the function on `SomethingOrNothing` `print2` to disambiguate from the `print` defined previously.
 // 
 // *Hint*: There is a macro `print!` for printing without appending a newline.
-trait Print {
+pub trait Print {
     /* Add things here */
 }
 impl<T: Print> SomethingOrNothing<T> {

--- a/workspace/src/part15.rs
+++ b/workspace/src/part15.rs
@@ -3,6 +3,7 @@
 
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 
 // The derived `Clone` implementation will clone the `Arc`, so all clones will actually talk about the same counter.
@@ -36,7 +37,7 @@ pub fn main() {
     let counter1 = counter.clone();
     let handle1 = thread::spawn(move || {
         for _ in 0..10 {
-            thread::sleep_ms(15);
+            thread::sleep(Duration::from_millis(15));
             counter1.increment(2);
         }
     });
@@ -45,14 +46,14 @@ pub fn main() {
     let counter2 = counter.clone();
     let handle2 = thread::spawn(move || {
         for _ in 0..10 {
-            thread::sleep_ms(20);
+            thread::sleep(Duration::from_millis(20));
             counter2.increment(3);
         }
     });
 
     // Now we watch the threads working on the counter.
     for _ in 0..50 {
-        thread::sleep_ms(5);
+        thread::sleep(Duration::from_millis(5));
         println!("Current value: {}", counter.get());
     }
 


### PR DESCRIPTION
Dear Ralf,

thanks a lot for your tutorial. When using rustic 1.7.0 i got some warnings.
This pull request fixes them.

Best
Stefan
