### PR TITLE
Rewrite test_invariant() in functional style

### DIFF
--- a/src/part05.rs
+++ b/src/part05.rs
@@ -40,11 +40,7 @@ impl BigInt {
     //@ It can often be useful to encode the invariant of a data-structure in code, so here
     //@ is a check that detects useless trailing zeros.
     pub fn test_invariant(&self) -> bool {
-        if self.data.len() == 0 {
-            true
-        } else {
-            self.data[self.data.len() - 1] != 0                     /*@*/
-        }
+        self.data.last().map_or(true, |&last| last != 0)            /*@*/
     }
 
     // We can convert any vector of digits into a number, by removing trailing zeros. The `mut`


### PR DESCRIPTION
Original code tests for emptiness with `if len() == 0`, then accesses the last one with index arithmetic. A more idiomatic and functional way would be using method `last()` from `std::vec::Vec`, which returns an `Option<&u64>` in this case that can be mapped over. 

`map_or()` from `std::option::Option` is used here for providing the default `true` in case `data` is empty. The closure parameter is destructured to take out the value as `last`.

Advantage of this code is to showcase a benefit of `Option` other than its expressiveness.

Problem of this code is that it uses closure, which is not introduced until part 10. Some possible solutions:

1. Move closure to before here;
2. Make refactoring this function an exercise in part 10;
3. Introduce closure here, noting part 10.